### PR TITLE
api routes before sendfile

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,6 +15,9 @@ app.use(bodyParser.json());
 app.use(formData.parse());
 app.use(express.static(path.join(__dirname, "client", "build")));
 
+//Routing Config
+app.use("/users", user);
+
 app.get("*", (req, res) => {
   res.sendFile(path.join(__dirname, "client", "build", "index.html"));
 });
@@ -27,9 +30,6 @@ mongoose
   .connect(process.env.MONGODB_URI, { useNewUrlParser: true })
   .then(() => console.log("mongodb connected"))
   .catch(err => console.log(err));
-
-//Routing Config
-app.use("/users", user);
 
 //Cloudinary Config
 


### PR DESCRIPTION
you need to declare your api routes before res.sendfile.  `app.get("*"` ... is to send back index.html for anything that doesn't match the above. [medium](https://medium.com/@chloechong.us/how-to-deploy-a-create-react-app-with-an-express-backend-to-heroku-32decfee6d18) 